### PR TITLE
Fix BibInject workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -58,9 +58,9 @@ jobs:
 
       - name: Prepare deployment folder
         run: |
+          rm -rf public
           mkdir public
-          shopt -s extglob
-          cp -r !(tools|public) public/
+          rsync -av --exclude tools/ --exclude public/ ./ public/
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4


### PR DESCRIPTION
This PR updates the deployment workflow to use `rsync` instead of Bash `extglob` + `cp` when preparing the `public/` directory.

The previous approach relied on shell glob expansion, which is fragile and can fail in edge cases. Using `rsync` makes the deployment step more robust and predictable.

---

## What changed

* Removed Bash `extglob` usage
* Replaced `cp -r !(tools|public)` with `rsync -av`
* Explicitly excluded `tools/` and `public/`
* Ensured the `public/` directory is recreated cleanly before syncing

---

## Why this change

Using `rsync` instead of `cp`:

* Correctly handles dotfiles (e.g. `.env`, `.gitignore`)
* Avoids shell globbing edge cases
* Scales better with large file sets
* Is safer and more predictable in CI environments
* Preserves file metadata

---

## Checklist

* [x] Workflow now works as expected
* [x] Deployment artifacts include expected files
* [x] No breaking changes introduced

Resolves #52